### PR TITLE
fix: make deleted_at field optional in schema

### DIFF
--- a/prisma/migrations/20221030050202_deleted_at/migration.sql
+++ b/prisma/migrations/20221030050202_deleted_at/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE `items` MODIFY `delete_at` DATETIME(3) NULL;
+
+-- AlterTable
+ALTER TABLE `mitra` MODIFY `delete_at` DATETIME(3) NULL;
+
+-- AlterTable
+ALTER TABLE `unit` MODIFY `delete_at` DATETIME(3) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,7 @@ model Mitra {
 
   created_at DateTime    @default(now())
   update_at  DateTime    @updatedAt
-  delete_at  DateTime
+  delete_at  DateTime?
   createdBy  User?       @relation("mitraCreatedBy", fields: [created_by], references: [id])
   created_by Int?
   updatedBy  User?       @relation("mitraUpdatedBy", fields: [updated_by], references: [id])
@@ -65,14 +65,14 @@ model Unit {
   unit_name String  @db.VarChar(30)
   active    Boolean @default(true)
 
-  created_at DateTime @default(now())
-  update_at  DateTime @updatedAt
-  delete_at  DateTime
-  createdBy  User?    @relation("unitCreatedBy", fields: [created_by], references: [id])
+  created_at DateTime  @default(now())
+  update_at  DateTime  @updatedAt
+  delete_at  DateTime?
+  createdBy  User?     @relation("unitCreatedBy", fields: [created_by], references: [id])
   created_by Int?
-  updatedBy  User?    @relation("unitUpdatedBy", fields: [updated_by], references: [id])
+  updatedBy  User?     @relation("unitUpdatedBy", fields: [updated_by], references: [id])
   updated_by Int?
-  deletedBy  User?    @relation("unitDeletedBy", fields: [deleted_by], references: [id])
+  deletedBy  User?     @relation("unitDeletedBy", fields: [deleted_by], references: [id])
   deleted_by Int?
   Items      Items[]
 }
@@ -92,7 +92,7 @@ model Items {
 
   created_at      DateTime          @default(now())
   update_at       DateTime          @updatedAt
-  delete_at       DateTime
+  delete_at       DateTime?
   createdBy       User?             @relation("itemsCreatedBy", fields: [created_by], references: [id])
   created_by      Int?
   updatedBy       User?             @relation("itemsUpdatedBy", fields: [updated_by], references: [id])

--- a/src/Modules/Auth/auth.service.ts
+++ b/src/Modules/Auth/auth.service.ts
@@ -19,7 +19,7 @@ export class AuthService {
   ) {}
 
   async login(body: LoginDto) {
-    const user = await this.prisma.user.findUnique({
+    const user = await this.prisma.user.findFirst({
       where: { username: body.username },
     });
     if (!user) throw new BadRequestException('Username atau password salah');


### PR DESCRIPTION
# Description
make deleted_at field optional in schema

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
